### PR TITLE
fix: remove optional keyword from protobuf definition

### DIFF
--- a/w3name/src/ipns/ipns_pb.proto
+++ b/w3name/src/ipns/ipns_pb.proto
@@ -8,32 +8,32 @@ message IpnsEntry {
 	}
 
 	// value to be stored in the record
-  optional bytes value = 1;
+  bytes value = 1;
 
 	// signature of the record
-	optional bytes signature = 2;
+	bytes signature = 2;
 
 	// Type of validation being used
-	optional ValidityType validityType = 3;
+	ValidityType validityType = 3;
 
 	// expiration datetime for the record in RFC3339 format
-	optional bytes validity = 4;
+	bytes validity = 4;
 
 	// number representing the version of the record
-	optional uint64 sequence = 5;
+	uint64 sequence = 5;
 
 	// ttl in nanoseconds
-	optional uint64 ttl = 6;
+	uint64 ttl = 6;
 
 	// in order for nodes to properly validate a record upon receipt, they need the public
 	// key associated with it. For old RSA keys, its easiest if we just send this as part of
 	// the record itself. For newer ed25519 keys, the public key can be embedded in the
 	// peerID, making this field unnecessary.
-	optional bytes pubKey = 7;
+	bytes pubKey = 7;
 
 	// the v2 signature of the record
-	optional bytes signatureV2 = 8;
+	bytes signatureV2 = 8;
 
 	// extensible data
-	optional bytes data = 9;
+	bytes data = 9;
 }


### PR DESCRIPTION
This fixes the invalid proto3 syntax by removing the `optional` keyword from all the fields  in the protobuf file.
Also updates the code in `ipns/mod.rs` a bit, since the generated types no longer have `Option<T>` for the various fields.

As far as I can tell, everything still works, so :sunglasses: 

I haven't tried testing with the protobuf version that was failing before, but if it happens again we can open a new issue. Closes #5.