### PR TITLE
add doc comments, plus some small API changes

### DIFF
--- a/w3name-cli/src/main.rs
+++ b/w3name-cli/src/main.rs
@@ -95,7 +95,7 @@ fn create(output: &Option<PathBuf>) -> Result<(), CliError> {
 async fn publish(key_file: &PathBuf, value: &str) -> Result<(), CliError> {
   let client = W3NameClient::default();
   let key_bytes = fs::read(key_file).report().change_context(CliError)?;
-  let writable = WritableName::from_private_key(&key_bytes).change_context(CliError)?;
+  let writable = WritableName::decode(&key_bytes).change_context(CliError)?;
 
   // to avoid having to keep old revisions around, we first try to resolve and increment any existing records
   let new_revision = match client.resolve(&writable.to_name()).await {

--- a/w3name-cli/src/main.rs
+++ b/w3name-cli/src/main.rs
@@ -35,9 +35,8 @@ enum Commands {
 
   /// Create a new public/private keypair and save it to disk.
   Create {
-
     /// Filename to write the key to.
-    /// 
+    ///
     /// If not given, will write to a file named `<name>.key`,
     /// where `<name>` is the string form of the public key.
     #[clap(short, long, value_parser)]

--- a/w3name/src/hash.rs
+++ b/w3name/src/hash.rs
@@ -1,6 +1,5 @@
 use multihash::derive::Multihash;
 
-
 /// Hasher is a custom Multihash "code table" with just the identity hash function enabled.
 #[derive(Clone, Copy, Debug, Eq, Multihash, PartialEq)]
 #[mh(alloc_size = 64)]

--- a/w3name/src/hash.rs
+++ b/w3name/src/hash.rs
@@ -1,0 +1,10 @@
+use multihash::derive::Multihash;
+
+
+/// Hasher is a custom Multihash "code table" with just the identity hash function enabled.
+#[derive(Clone, Copy, Debug, Eq, Multihash, PartialEq)]
+#[mh(alloc_size = 64)]
+pub enum Hasher {
+  #[mh(code = 0x0, hasher = multihash::IdentityHasher::<64>)]
+  Identity,
+}

--- a/w3name/src/ipns/mod.rs
+++ b/w3name/src/ipns/mod.rs
@@ -64,7 +64,8 @@ pub fn deserialize_ipns_entry(entry_bytes: &[u8]) -> Result<IpnsEntry, IpnsError
 
 pub fn validate_ipns_entry(entry: &IpnsEntry, public_key: &PublicKey) -> Result<(), IpnsError> {
   if !entry.signature_v2.is_empty() && !entry.data.is_empty() {
-    validate_v2_signature(public_key, &entry.signature_v2, &entry.data).change_context(IpnsError)?;
+    validate_v2_signature(public_key, &entry.signature_v2, &entry.data)
+      .change_context(IpnsError)?;
     validate_v2_data_matches_entry_data(entry).change_context(IpnsError)?;
 
     return Ok(());
@@ -74,9 +75,7 @@ pub fn validate_ipns_entry(entry: &IpnsEntry, public_key: &PublicKey) -> Result<
 }
 
 pub fn revision_from_ipns_entry(entry: &IpnsEntry, name: &Name) -> Result<Revision, IpnsError> {
-  let value = from_utf8(&entry.value)
-    .report()
-    .change_context(IpnsError)?;
+  let value = from_utf8(&entry.value).report().change_context(IpnsError)?;
   let validity_str = from_utf8(&entry.validity)
     .report()
     .change_context(IpnsError)?;

--- a/w3name/src/lib.rs
+++ b/w3name/src/lib.rs
@@ -1,3 +1,37 @@
+//! A client library for the w3name distributed naming service.
+//! 
+//! This library contains an HTTP client for the [w3name service](https://github.com/web3-storage/w3name),
+//! an implementation of the [IPNS](https://docs.ipfs.tech/concepts/ipns/) decentralized naming protocol.
+//! 
+//! w3name allows permissionless creation and publication of name records, which are signed with a private key
+//! that corresponds to a public key embedded in the name identifier.
+//! 
+//! Name identifiers are the string form of a public key, encoded as a [CID](https://docs.ipfs.tech/concepts/content-addressing/).
+//! They look something like this: `k51qzi5uqu5dka3tmn6ipgsrq1u2bkuowdwlqcw0vibledypt1y9y5i8v8xwvu`
+//! 
+//! The `w3name` crate provides a few types for working with names and name records:
+//! - [Name] is a representation of a name identifier. It contains the public verification key.
+//!   `Name`s can be used to fetch and verify the latest published value for a name record.
+//! - [WritableName] contains a private key that can be used to sign and publish name records.
+//! - [Revision] represents an unsigned name record. It contains a string value and some metadata (sequence number, expiration date, etc).
+//! 
+//! The [W3NameClient] type provides a [reqwest](https://docs.rs/reqwest/latest/reqwest/)-based HTTP client
+//! for the w3name service. Using the client, you can [resolve](W3NameClient::resolve) the value for a [Name] and/or
+//! [publish](W3NameClient::publish) a new [Revision] for a [WritableName].
+//! 
+//! Note that the client requires a [tokio](https://tokio.rs) runtime, as it uses the async reqwest implementation.
+//! For a real-world example of using the client, see [w3name-cli](https://crates.io/crates/w3name-cli).
+//! 
+//! ## Errors
+//! 
+//! This crate uses the [error-stack](https://docs.rs/error-stack/latest/error_stack/) library for error handling,
+//! so all `Err` branches of `Result`s return a `Report<E>`, where `Report` is an 
+//! [error-stack `Report` struct](https://docs.rs/error-stack/latest/error_stack/struct.Report.html) and `E` is
+//! one of the types defined in this crate's [error] module. 
+//! 
+//! If you don't care about the full report, you can get the error instance out of the `Report` using 
+//! [`Report::current_context()`](https://docs.rs/error-stack/latest/error_stack/struct.Report.html#method.current_context).
+
 mod client;
 pub mod error;
 mod ipns;

--- a/w3name/src/lib.rs
+++ b/w3name/src/lib.rs
@@ -34,6 +34,7 @@
 
 mod client;
 pub mod error;
+mod hash;
 mod ipns;
 mod name;
 mod revision;

--- a/w3name/src/lib.rs
+++ b/w3name/src/lib.rs
@@ -1,35 +1,35 @@
 //! A client library for the w3name distributed naming service.
-//! 
+//!
 //! This library contains an HTTP client for the [w3name service](https://github.com/web3-storage/w3name),
 //! an implementation of the [IPNS](https://docs.ipfs.tech/concepts/ipns/) decentralized naming protocol.
-//! 
+//!
 //! w3name allows permissionless creation and publication of name records, which are signed with a private key
 //! that corresponds to a public key embedded in the name identifier.
-//! 
+//!
 //! Name identifiers are the string form of a public key, encoded as a [CID](https://docs.ipfs.tech/concepts/content-addressing/).
 //! They look something like this: `k51qzi5uqu5dka3tmn6ipgsrq1u2bkuowdwlqcw0vibledypt1y9y5i8v8xwvu`
-//! 
+//!
 //! The `w3name` crate provides a few types for working with names and name records:
 //! - [Name] is a representation of a name identifier. It contains the public verification key.
 //!   `Name`s can be used to fetch and verify the latest published value for a name record.
 //! - [WritableName] contains a private key that can be used to sign and publish name records.
 //! - [Revision] represents an unsigned name record. It contains a string value and some metadata (sequence number, expiration date, etc).
-//! 
+//!
 //! The [W3NameClient] type provides a [reqwest](https://docs.rs/reqwest/latest/reqwest/)-based HTTP client
 //! for the w3name service. Using the client, you can [resolve](W3NameClient::resolve) the value for a [Name] and/or
 //! [publish](W3NameClient::publish) a new [Revision] for a [WritableName].
-//! 
+//!
 //! Note that the client requires a [tokio](https://tokio.rs) runtime, as it uses the async reqwest implementation.
 //! For a real-world example of using the client, see [w3name-cli](https://crates.io/crates/w3name-cli).
-//! 
+//!
 //! ## Errors
-//! 
+//!
 //! This crate uses the [error-stack](https://docs.rs/error-stack/latest/error_stack/) library for error handling,
-//! so all `Err` branches of `Result`s return a `Report<E>`, where `Report` is an 
+//! so all `Err` branches of `Result`s return a `Report<E>`, where `Report` is an
 //! [error-stack `Report` struct](https://docs.rs/error-stack/latest/error_stack/struct.Report.html) and `E` is
-//! one of the types defined in this crate's [error] module. 
-//! 
-//! If you don't care about the full report, you can get the error instance out of the `Report` using 
+//! one of the types defined in this crate's [error] module.
+//!
+//! If you don't care about the full report, you can get the error instance out of the `Report` using
 //! [`Report::current_context()`](https://docs.rs/error-stack/latest/error_stack/struct.Report.html#method.current_context).
 
 mod client;

--- a/w3name/src/name.rs
+++ b/w3name/src/name.rs
@@ -3,11 +3,10 @@ use std::fmt::Display;
 use cid::Cid;
 use libp2p_core::identity::{Keypair, PublicKey};
 use multibase::Base;
-use multihash::derive::Multihash;
+use crate::hash::Hasher;
 use multihash::MultihashDigest;
 
-// we need to rename Result here, because the multihash derive macro gets confused otherwise
-use error_stack::{report, IntoReport, Result as ResultStack, ResultExt};
+use error_stack::{report, IntoReport, Result, ResultExt};
 
 use crate::error::{InvalidCidString, InvalidMulticodecCode, NameError};
 
@@ -41,7 +40,7 @@ impl Name {
   /// let invalid_name_str = "not a valid public key string";
   /// assert!(Name::parse(invalid_name_str).is_err());
   /// ```
-  pub fn parse<S: AsRef<str>>(s: S) -> ResultStack<Name, NameError> {
+  pub fn parse<S: AsRef<str>>(s: S) -> Result<Name, NameError> {
     let res = Cid::try_from(s.as_ref());
     let c = res
       .map_err(|_| InvalidCidString)
@@ -154,7 +153,7 @@ impl WritableName {
     WritableName(kp)
   }
 
-  pub fn from_private_key(key_bytes: &[u8]) -> ResultStack<WritableName, NameError> {
+  pub fn from_private_key(key_bytes: &[u8]) -> Result<WritableName, NameError> {
     let mut kb = key_bytes.to_vec(); // from_protobuf_encoding takes &mut, so clone instead of requiring the same
     let kp = Keypair::from_protobuf_encoding(&mut kb)
       .report()
@@ -189,12 +188,7 @@ impl Display for WritableName {
   }
 }
 
-#[derive(Clone, Copy, Debug, Eq, Multihash, PartialEq)]
-#[mh(alloc_size = 64)]
-enum Hasher {
-  #[mh(code = 0x0, hasher = multihash::IdentityHasher::<64>)]
-  Identity,
-}
+
 
 #[cfg(test)]
 mod tests {

--- a/w3name/src/name.rs
+++ b/w3name/src/name.rs
@@ -30,15 +30,19 @@ impl Name {
   /// ## Example
   /// 
   /// ```rust
+  /// # fn main() -> error_stack::Result<(), w3name::error::NameError> {
   /// use w3name::Name;
   /// 
   /// let name_str = "k51qzi5uqu5dka3tmn6ipgsrq1u2bkuowdwlqcw0vibledypt1y9y5i8v8xwvu";
-  /// let name = Name::parse(name_str).unwrap();
+  /// let name = Name::parse(name_str)?;
   /// 
   /// assert_eq!(name_str, &name.to_string());
   /// 
   /// let invalid_name_str = "not a valid public key string";
   /// assert!(Name::parse(invalid_name_str).is_err());
+  /// 
+  /// # Ok(())
+  /// # }
   /// ```
   pub fn parse<S: AsRef<str>>(s: S) -> Result<Name, NameError> {
     let res = Cid::try_from(s.as_ref());
@@ -62,15 +66,19 @@ impl Name {
   /// ## Example
   /// 
   /// ```rust
+  /// # fn main() -> error_stack::Result<(), w3name::error::NameError> {
   /// use w3name::Name;
   /// use libp2p_core::identity::PublicKey;
   /// 
-  /// let name = Name::parse("k51qzi5uqu5dka3tmn6ipgsrq1u2bkuowdwlqcw0vibledypt1y9y5i8v8xwvu").unwrap();
+  /// let name = Name::parse("k51qzi5uqu5dka3tmn6ipgsrq1u2bkuowdwlqcw0vibledypt1y9y5i8v8xwvu")?;
   /// 
   /// match name.public_key() {
   ///   &PublicKey::Ed25519(_) => println!("it's an ed25519 key, alright"),
   ///   _ => panic!("that's odd, I could have sworn that the key was ed25519..."),
   /// }
+  /// 
+  /// # Ok(())
+  /// # }
   /// 
   /// ```
   pub fn public_key(&self) -> &PublicKey {
@@ -82,15 +90,18 @@ impl Name {
   /// ## Example
   /// 
   /// ```rust
+  /// # fn main() -> error_stack::Result<(), w3name::error::NameError> {
   /// use w3name::Name;
   /// 
-  /// let name = Name::parse("k51qzi5uqu5dka3tmn6ipgsrq1u2bkuowdwlqcw0vibledypt1y9y5i8v8xwvu").unwrap();
+  /// let name = Name::parse("k51qzi5uqu5dka3tmn6ipgsrq1u2bkuowdwlqcw0vibledypt1y9y5i8v8xwvu")?;
   /// 
   /// let cid = name.to_cid();
   /// // Cid::to_string() returns a base32-encoded string, but w3name uses base36.
   /// 
   /// let expected_cid_string = "bafzaajaiaejcbjdinwzcqwpdydtsxcfnvu2qak2zqpsss5zqqf5od54tk4ufkcf2";
   /// assert_eq!(&cid.to_string(), expected_cid_string);
+  /// # Ok(())
+  /// # }
   /// ```
   pub fn to_cid(&self) -> Cid {
     let key_bytes = self.0.to_protobuf_encoding();
@@ -103,15 +114,18 @@ impl Name {
   /// ## Example
   /// 
   /// ```rust
+  /// # fn main() -> error_stack::Result<(), w3name::error::NameError> {
   /// use w3name::Name;
   /// use cid::Cid;
   /// 
-  /// let name = Name::parse("k51qzi5uqu5dka3tmn6ipgsrq1u2bkuowdwlqcw0vibledypt1y9y5i8v8xwvu").unwrap();
+  /// let name = Name::parse("k51qzi5uqu5dka3tmn6ipgsrq1u2bkuowdwlqcw0vibledypt1y9y5i8v8xwvu")?;
   /// 
   /// let bytes = name.to_bytes();
   /// let cid = Cid::read_bytes(&bytes[..]).unwrap();
   /// 
   /// assert_eq!(cid, name.to_cid());
+  /// # Ok(())
+  /// # }
   /// ```
   pub fn to_bytes(&self) -> Vec<u8> {
     self.to_cid().to_bytes()
@@ -125,12 +139,15 @@ impl Name {
   /// ## Example
   /// 
   /// ```rust
+  /// # fn main() -> error_stack::Result<(), w3name::error::NameError> {
   /// use w3name::Name;
   /// 
   /// let name_str = "k51qzi5uqu5dka3tmn6ipgsrq1u2bkuowdwlqcw0vibledypt1y9y5i8v8xwvu";
-  /// let name = Name::parse(name_str).unwrap();
+  /// let name = Name::parse(name_str)?;
   /// 
   /// assert_eq!(name_str, &name.to_string());
+  /// # Ok(())
+  /// # }
   /// ```
   pub fn to_string(&self) -> String {
     self.to_cid().to_string_of_base(Base::Base36Lower).unwrap()
@@ -163,13 +180,18 @@ impl WritableName {
   /// ## Example
   /// 
   /// ```rust
+  /// # fn main() -> error_stack::Result<(), w3name::error::ProtobufError> {
+  /// 
   /// use w3name::WritableName;
   /// 
   /// let w = WritableName::new();
-  /// let bytes = w.encode().unwrap();
-  /// let w2 = WritableName::decode(&bytes).unwrap();
+  /// let bytes = w.encode()?;
+  /// let w2 = WritableName::decode(&bytes)?;
   /// 
   /// assert_eq!(w, w2);
+  /// 
+  /// # Ok(())
+  /// # }
   /// ```
   pub fn decode(key_bytes: &[u8]) -> Result<WritableName, ProtobufError> {
     let mut kb = key_bytes.to_vec(); // from_protobuf_encoding takes &mut, so clone instead of requiring the same
@@ -184,13 +206,16 @@ impl WritableName {
   /// ## Example
   /// 
   /// ```rust
+  /// # fn main() -> error_stack::Result<(), w3name::error::ProtobufError> {
   /// use w3name::WritableName;
   /// 
   /// let w = WritableName::new();
-  /// let bytes = w.encode().unwrap();
-  /// let w2 = WritableName::decode(&bytes).unwrap();
+  /// let bytes = w.encode()?;
+  /// let w2 = WritableName::decode(&bytes)?;
   /// 
   /// assert_eq!(w, w2);
+  /// # Ok(())
+  /// # }
   /// ``` 
   pub fn encode(&self) -> Result<Vec<u8>, ProtobufError> {
     self.keypair().to_protobuf_encoding().report().change_context(ProtobufError)

--- a/w3name/src/name.rs
+++ b/w3name/src/name.rs
@@ -1,9 +1,9 @@
 use std::fmt::Display;
 
+use crate::{error::ProtobufError, hash::Hasher};
 use cid::Cid;
 use libp2p_core::identity::{Keypair, PublicKey};
 use multibase::Base;
-use crate::{hash::Hasher, error::ProtobufError};
 use multihash::MultihashDigest;
 
 use error_stack::{report, IntoReport, Result, ResultExt};
@@ -26,21 +26,21 @@ pub struct Name(PublicKey);
 
 impl Name {
   /// Parses a `Name` from the string form of a name identifier.
-  /// 
+  ///
   /// ## Example
-  /// 
+  ///
   /// ```rust
   /// # fn main() -> error_stack::Result<(), w3name::error::NameError> {
   /// use w3name::Name;
-  /// 
+  ///
   /// let name_str = "k51qzi5uqu5dka3tmn6ipgsrq1u2bkuowdwlqcw0vibledypt1y9y5i8v8xwvu";
   /// let name = Name::parse(name_str)?;
-  /// 
+  ///
   /// assert_eq!(name_str, &name.to_string());
-  /// 
+  ///
   /// let invalid_name_str = "not a valid public key string";
   /// assert!(Name::parse(invalid_name_str).is_err());
-  /// 
+  ///
   /// # Ok(())
   /// # }
   /// ```
@@ -62,42 +62,42 @@ impl Name {
   }
 
   /// Returns a reference to this `Name`'s [PublicKey].
-  /// 
+  ///
   /// ## Example
-  /// 
+  ///
   /// ```rust
   /// # fn main() -> error_stack::Result<(), w3name::error::NameError> {
   /// use w3name::Name;
   /// use libp2p_core::identity::PublicKey;
-  /// 
+  ///
   /// let name = Name::parse("k51qzi5uqu5dka3tmn6ipgsrq1u2bkuowdwlqcw0vibledypt1y9y5i8v8xwvu")?;
-  /// 
+  ///
   /// match name.public_key() {
   ///   &PublicKey::Ed25519(_) => println!("it's an ed25519 key, alright"),
   ///   _ => panic!("that's odd, I could have sworn that the key was ed25519..."),
   /// }
-  /// 
+  ///
   /// # Ok(())
   /// # }
-  /// 
+  ///
   /// ```
   pub fn public_key(&self) -> &PublicKey {
     &self.0
   }
 
   /// Returns this `Name` encoded as a [Cid], using the "identity" hash function to embed the key into the Cid itself.
-  /// 
+  ///
   /// ## Example
-  /// 
+  ///
   /// ```rust
   /// # fn main() -> error_stack::Result<(), w3name::error::NameError> {
   /// use w3name::Name;
-  /// 
+  ///
   /// let name = Name::parse("k51qzi5uqu5dka3tmn6ipgsrq1u2bkuowdwlqcw0vibledypt1y9y5i8v8xwvu")?;
-  /// 
+  ///
   /// let cid = name.to_cid();
   /// // Cid::to_string() returns a base32-encoded string, but w3name uses base36.
-  /// 
+  ///
   /// let expected_cid_string = "bafzaajaiaejcbjdinwzcqwpdydtsxcfnvu2qak2zqpsss5zqqf5od54tk4ufkcf2";
   /// assert_eq!(&cid.to_string(), expected_cid_string);
   /// # Ok(())
@@ -110,19 +110,19 @@ impl Name {
   }
 
   /// Returns a `Vec<u8>` containing the binary form of the [Cid] representing this `Name`.
-  /// 
+  ///
   /// ## Example
-  /// 
+  ///
   /// ```rust
   /// # fn main() -> error_stack::Result<(), w3name::error::NameError> {
   /// use w3name::Name;
   /// use cid::Cid;
-  /// 
+  ///
   /// let name = Name::parse("k51qzi5uqu5dka3tmn6ipgsrq1u2bkuowdwlqcw0vibledypt1y9y5i8v8xwvu")?;
-  /// 
+  ///
   /// let bytes = name.to_bytes();
   /// let cid = Cid::read_bytes(&bytes[..]).unwrap();
-  /// 
+  ///
   /// assert_eq!(cid, name.to_cid());
   /// # Ok(())
   /// # }
@@ -132,19 +132,19 @@ impl Name {
   }
 
   /// Returns the public key in the "canonical" string format for name identifiers used by w3name.
-  /// 
+  ///
   /// The returned string is a base36-encoded representation of [Name::to_cid()].
   /// This is the same format expected by [Name::parse()].
-  /// 
+  ///
   /// ## Example
-  /// 
+  ///
   /// ```rust
   /// # fn main() -> error_stack::Result<(), w3name::error::NameError> {
   /// use w3name::Name;
-  /// 
+  ///
   /// let name_str = "k51qzi5uqu5dka3tmn6ipgsrq1u2bkuowdwlqcw0vibledypt1y9y5i8v8xwvu";
   /// let name = Name::parse(name_str)?;
-  /// 
+  ///
   /// assert_eq!(name_str, &name.to_string());
   /// # Ok(())
   /// # }
@@ -161,14 +161,13 @@ impl Display for Name {
 }
 
 /// `WritableName` represnts a public/private keypair that can be used to sign name records for publication.
-/// 
+///
 /// You can use a `WritableName` to publish a value to the w3name service using [W3NameClient::publish()](crate::W3NameClient::publish).
-/// 
+///
 #[derive(Clone, Debug)]
 pub struct WritableName(Keypair);
 
 impl WritableName {
-
   /// Creates a new `WritableName` by generating an ed25519 keypair.
   pub fn new() -> WritableName {
     let kp = Keypair::generate_ed25519();
@@ -176,20 +175,20 @@ impl WritableName {
   }
 
   /// Decodes a `WritableName` from a binary encoding of a keypair as produced by [encode](Self::encode).
-  /// 
+  ///
   /// ## Example
-  /// 
+  ///
   /// ```rust
   /// # fn main() -> error_stack::Result<(), w3name::error::ProtobufError> {
-  /// 
+  ///
   /// use w3name::WritableName;
-  /// 
+  ///
   /// let w = WritableName::new();
   /// let bytes = w.encode()?;
   /// let w2 = WritableName::decode(&bytes)?;
-  /// 
+  ///
   /// assert_eq!(w, w2);
-  /// 
+  ///
   /// # Ok(())
   /// # }
   /// ```
@@ -204,31 +203,35 @@ impl WritableName {
   /// Encodes a `WritableName` into a binary representation, suitable for [decode](Self::decode).
   ///
   /// ## Example
-  /// 
+  ///
   /// ```rust
   /// # fn main() -> error_stack::Result<(), w3name::error::ProtobufError> {
   /// use w3name::WritableName;
-  /// 
+  ///
   /// let w = WritableName::new();
   /// let bytes = w.encode()?;
   /// let w2 = WritableName::decode(&bytes)?;
-  /// 
+  ///
   /// assert_eq!(w, w2);
   /// # Ok(())
   /// # }
-  /// ``` 
+  /// ```
   pub fn encode(&self) -> Result<Vec<u8>, ProtobufError> {
-    self.keypair().to_protobuf_encoding().report().change_context(ProtobufError)
+    self
+      .keypair()
+      .to_protobuf_encoding()
+      .report()
+      .change_context(ProtobufError)
   }
 
   /// Returns a reference to this `WritableName`'s underlying [Keypair].
-  /// 
+  ///
   /// ## Example
-  /// 
+  ///
   /// ```rust
   /// use w3name::WritableName;
   /// use libp2p_core::identity::Keypair;
-  /// 
+  ///
   /// let w = WritableName::new();
   /// match w.keypair() {
   ///   &Keypair::Ed25519(_) => println!("it's an ed25519 keypair!"),
@@ -242,13 +245,13 @@ impl WritableName {
   /// Returns a `Name` that represents the public half of this `WritableName`'s keypair.
   ///
   /// ## Example
-  /// 
+  ///
   /// ```rust
   /// use w3name::WritableName;
-  /// 
+  ///
   /// let w = WritableName::new();
   /// let n = w.to_name();
-  /// 
+  ///
   /// assert_eq!(&w.keypair().public(), n.public_key());
   /// ```
   pub fn to_name(&self) -> Name {
@@ -256,18 +259,18 @@ impl WritableName {
   }
 
   /// Convenience wrapper around `Self::to_name().to_cid()` that returns the Cid form of the **public** portion of this `WritableName`'s keypair.
-  /// 
-  /// Please note that this does not encode the private key. 
+  ///
+  /// Please note that this does not encode the private key.
   /// If you want to save the `WritableName`, use [encode](Self::encode).
-  /// 
+  ///
   /// ## Example
-  /// 
+  ///
   /// ```rust
   /// use w3name::WritableName;
-  /// 
+  ///
   /// let w = WritableName::new();
   /// let n = w.to_name();
-  /// 
+  ///
   /// assert_eq!(w.to_cid(), n.to_cid());
   /// ```
   pub fn to_cid(&self) -> Cid {
@@ -275,18 +278,18 @@ impl WritableName {
   }
 
   /// Convenience wrapper around `Self::to_name().to_string()` that returns a string encoding of the public key (aka the "name identifier").
-  /// 
+  ///
   /// Please note that this does not encode the private key.
   /// If you want to save the `WritableName`, use [encode](Self::encode).
-  /// 
+  ///
   /// ## Example
-  /// 
+  ///
   /// ```rust
   /// use w3name::WritableName;
-  /// 
+  ///
   /// let w = WritableName::new();
   /// let n = w.to_name();
-  /// 
+  ///
   /// assert_eq!(w.to_string(), n.to_string());
   pub fn to_string(&self) -> String {
     self.to_name().to_string()
@@ -311,7 +314,7 @@ impl PartialEq for WritableName {
         let our_key_bytes = our_key.encode();
         let their_key_bytes = their_key.encode();
         our_key_bytes == their_key_bytes
-      },
+      }
 
       // we only support Ed25519 keys, so if we have anything else, return false
       _ => false,

--- a/w3name/src/revision.rs
+++ b/w3name/src/revision.rs
@@ -2,6 +2,15 @@ use crate::{name::Name, error::CborError};
 use chrono::{DateTime, Duration, SecondsFormat, Utc};
 use error_stack::{Result, ResultExt, IntoReport};
 
+/// A `Revision` represents a single value for a name record.
+/// 
+/// A `Revision` is essentially an IPNS entry without a signature, and it
+/// contains all the information needed to construct an IPNS entry for signing.
+/// 
+/// Each `Revision` contains a sequence number, which must be incremented when publishing
+/// updates to an existing `Revision`. To create the initial `Revision` (with sequence number == 0),
+/// use [Revision::v0]. Subsequent `Revision`s are created by calling [increment](Revision::increment)
+/// on an existing `Revision`.
 #[derive(Debug, Eq, PartialEq)]
 pub struct Revision {
   name: Name,
@@ -11,7 +20,10 @@ pub struct Revision {
 }
 
 impl Revision {
-  pub fn new<S: AsRef<str>>(
+  /// Creates a new `Revision`, specifying all fields.
+  /// 
+  /// Note that this is crate-only; users should use [Self::v0] or [Self:::increment]
+  pub(crate) fn new<S: AsRef<str>>(
     name: &Name,
     value: S,
     validity: DateTime<Utc>,
@@ -27,10 +39,55 @@ impl Revision {
     }
   }
 
+  /// Creates the initial `Revision` for the given [Name], with a sequence number of 0 and the default validity period (1 year).
+  ///
+  /// ## Example
+  /// ```rust
+  /// # fn main() -> error_stack::Result<(), w3name::error::NameError> {
+  /// use w3name::{Name, Revision};
+  /// 
+  /// let name = Name::parse("k51qzi5uqu5dka3tmn6ipgsrq1u2bkuowdwlqcw0vibledypt1y9y5i8v8xwvu")?;
+  /// let rev = Revision::v0(&name, "an initial value");
+  /// 
+  /// assert_eq!(&name, rev.name());
+  /// assert_eq!(rev.value(), "an initial value");
+  /// # Ok(())
+  /// # }
+  /// 
+  /// 
+  /// ```
   pub fn v0<S: AsRef<str>>(name: &Name, value: S) -> Revision {
-    Revision::new(name, value, default_validity(), 0)
+    Revision {
+        name: name.clone(),
+        value: value.as_ref().to_string(),
+        sequence: 0,
+        validity: default_validity(),
+    }
   }
 
+  /// Creates the initial `Revision` for the given [Name], with an explicit validity period.
+  /// 
+  /// Note that `validity` is an end-of-life timestamp, not a duration.
+  /// 
+  /// ## Example
+  /// 
+  /// ```rust
+  /// # fn main () -> error_stack::Result<(), w3name::error::NameError> {
+  /// use w3name::{Name, Revision};
+  /// use chrono::{Duration, Utc};
+  /// 
+  /// // set the expiration date to two weeks from now:
+  /// let expiration_date = Utc::now().checked_add_signed(Duration::weeks(2)).unwrap();
+  /// 
+  /// let name = Name::parse("k51qzi5uqu5dka3tmn6ipgsrq1u2bkuowdwlqcw0vibledypt1y9y5i8v8xwvu")?;
+  /// let rev = Revision::v0_with_validity(&name, "an initial value", expiration_date);
+  ///
+  /// assert_eq!(&name, rev.name());
+  /// assert_eq!(rev.value(), "an initial value");
+  /// assert_eq!(rev.validity(), &expiration_date);
+  /// # Ok(())
+  /// # }
+  /// ```
   pub fn v0_with_validity<S: AsRef<str>>(
     name: &Name,
     value: S,
@@ -39,36 +96,91 @@ impl Revision {
     Revision::new(name, value, validity, 0)
   }
 
+  /// Creates a new `Revision` with the given `value` and an incremented sequence number, using the default validity period (1 year).
+  ///
+  /// ## Example
+  /// 
+  /// ```rust
+  /// # fn main() -> error_stack::Result<(), w3name::error::NameError> {
+  /// use w3name::{Name, Revision};
+  /// 
+  /// let name = Name::parse("k51qzi5uqu5dka3tmn6ipgsrq1u2bkuowdwlqcw0vibledypt1y9y5i8v8xwvu")?;
+  /// let rev = Revision::v0(&name, "an initial value");
+  /// let rev2 = rev.increment("a new value");
+  /// 
+  /// assert_eq!(&name, rev.name());
+  /// assert_eq!(&name, rev2.name());
+  /// assert_eq!(rev.sequence(), 0);
+  /// assert_eq!(rev2.sequence(), 1);
+  /// assert_eq!(rev.value(), "an initial value");
+  /// assert_eq!(rev2.value(), "a new value");
+  /// 
+  /// # Ok(())
+  /// # }
+  /// ```
   pub fn increment<S: AsRef<str>>(&self, value: S) -> Revision {
+    Self::increment_with_validity(&self, value, default_validity())
+  }
+
+  /// Creates a new `Revision` with the given `value` and an incremented sequence number, with an explicit validity period.
+  /// 
+  /// Note that `validity` is an end-of-life timestamp, not a duration.
+  pub fn increment_with_validity<S: AsRef<str>>(&self, value: S, validity: DateTime<Utc>) -> Revision {
     let sequence = self.sequence + 1;
     Revision {
       name: self.name.clone(),
       value: value.as_ref().to_string(),
       sequence,
-      validity: default_validity(),
+      validity,
     }
   }
 
+  /// Returns a reference to this `Revision`'s [Name].
   pub fn name(&self) -> &Name {
     &self.name
   }
 
+  /// Returns a reference to this `Revision`'s value.
   pub fn value(&self) -> &str {
     &self.value
   }
 
+  /// Returns this `Revision`'s sequence number.
   pub fn sequence(&self) -> u64 {
     self.sequence
   }
 
+  /// Returns this `Revision`'s validity period (end of life date).
   pub fn validity(&self) -> &DateTime<Utc> {
     &self.validity
   }
 
+  /// Returns this `Revision`'s validity period as a String, suitable for inclusion in an IPNS record.
   pub fn validity_string(&self) -> String {
     self.validity.to_rfc3339_opts(SecondsFormat::Nanos, true)
   }
 
+  /// Encodes this `Revision` to a binary form, suitable for use with [Revision::decode].
+  /// 
+  /// Note that encoded `Revision`s are not signed and cannot be used directly as IPNS records.
+  /// 
+  /// ## Example
+  /// 
+  /// ```rust
+  /// # fn main() -> error_stack::Result<(), w3name::error::CborError> {
+  /// use w3name::{Name, Revision};
+  /// 
+  /// let name = Name::parse("k51qzi5uqu5dka3tmn6ipgsrq1u2bkuowdwlqcw0vibledypt1y9y5i8v8xwvu").unwrap();
+  /// let rev = Revision::v0(&name, "an initial value"); 
+  /// 
+  /// let bytes = rev.encode()?;
+  /// let rev2 = Revision::decode(&bytes)?;
+  /// 
+  /// assert_eq!(rev, rev2);
+  /// 
+  /// # Ok(())
+  /// # }
+  /// ```
   pub fn encode(&self) -> Result<Vec<u8>, CborError> {
     let data = RevisionCbor {
       name: self.name.to_string(),
@@ -80,6 +192,24 @@ impl Revision {
     Ok(bytes)
   }
 
+  /// Decodes a `Revision` from a binary form as produced by [Revision::encode].
+  /// 
+  /// ## Example
+  /// 
+  /// ```rust
+  /// # fn main() -> error_stack::Result<(), w3name::error::CborError> {
+  /// use w3name::{Name, Revision};
+  /// 
+  /// let name = Name::parse("k51qzi5uqu5dka3tmn6ipgsrq1u2bkuowdwlqcw0vibledypt1y9y5i8v8xwvu").unwrap();
+  /// let rev = Revision::v0(&name, "an initial value"); 
+  /// 
+  /// let bytes = rev.encode()?;
+  /// let rev2 = Revision::decode(&bytes)?;
+  /// 
+  /// assert_eq!(rev, rev2);
+  /// 
+  /// # Ok(())
+  /// # }
   pub fn decode(bytes: &[u8]) -> Result<Revision, CborError> {
     let data: RevisionCbor = serde_cbor::from_slice(bytes).report().change_context(CborError)?;
     let name = Name::parse(data.name).change_context(CborError)?;


### PR DESCRIPTION
This adds doc comments to the public api to close #8.

I also ended up making a couple of small but breaking changes:

- `WritableName::from_private_key` is now `WritableName::decode`, and there's a matching `encode` method.
- `Revision::new` is now `pub(crate)` - users should use `v0` or `increment` instead, or parse from bytes. May revisit this in the future if a good use case presents itself.