### PR TITLE
fix: use new github token for release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -10,4 +10,5 @@ jobs:
     steps:
       - uses: google-github-actions/release-please-action@v3
         with:
+          token: ${{ secrets.RELEASE_PLEASE_GH_TOKEN }}
           command: manifest


### PR DESCRIPTION
Forgot that using the default token means that merging won't trigger new GH actions.