### PR TITLE
chore: fix cargo publish workflow

### DIFF
--- a/.github/workflows/cargo-publish.yml
+++ b/.github/workflows/cargo-publish.yml
@@ -8,6 +8,8 @@ name: Cargo publish
 
 jobs:
   cargo_publish:
+    name: Publish
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1


### PR DESCRIPTION
I should probably start validating these locally... but where's the fun in that?