### PR TITLE
fix: handle 404 errors, fix error handling for client.resolve

### DIFF
--- a/w3name/src/error.rs
+++ b/w3name/src/error.rs
@@ -24,11 +24,14 @@ impl Display for HttpError {
 impl Error for HttpError {}
 
 #[derive(Debug)]
-pub struct APIError(pub String);
+pub struct APIError { 
+  pub message: String,
+  pub status_code: reqwest::StatusCode,
+}
 
 impl Display for APIError {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    write!(f, "api error: {}", self.0)
+    write!(f, "api error: [{}] {}", self.status_code, self.message)
   }
 }
 


### PR DESCRIPTION
This fixes a couple things related to error handling:

- `W3NameClient::resolve` now actually checks the status code of the API response and returns errors
- `APIError` now includes the HTTP status code
- The cli now prints an error report to stderr on failure and calls `process::exit` instead of panicking
- The cli's `publish` command now only falls back to creating an initial revision if the request for the current revision returns 404. Other errors are treated as failures and printed. Closes #4 

