### PR TITLE
fix: use V2-only IPNS record format for w3name compatibility

### DIFF
--- a/w3name/src/ipns/mod.rs
+++ b/w3name/src/ipns/mod.rs
@@ -29,8 +29,15 @@ pub fn revision_to_ipns_entry(
   .change_context(IpnsError)?;
   let signature_v2 = create_v2_signature(signer, &data).change_context(IpnsError)?;
   
-  // V2-only mode: ONLY set signature_v2 and data fields
+  // V2-only mode: set signature_v2 and data fields
+  // Also populate the top-level fields to match what's in data
+  // This is required for validate_v2_data_matches_entry_data to pass
   let entry = IpnsEntry {
+    value: revision.value().as_bytes().to_vec(),
+    validity: revision.validity_string().as_bytes().to_vec(),
+    validity_type: 0, // EOL = 0
+    sequence: revision.sequence(),
+    ttl,
     signature_v2,
     data: data.clone(),
     ..Default::default()

--- a/w3name/src/ipns/mod.rs
+++ b/w3name/src/ipns/mod.rs
@@ -140,7 +140,7 @@ fn validate_v2_data_matches_entry_data(
     || entry.validity != data.Validity
     || entry.sequence != data.Sequence
     || entry.ttl != data.TTL
-    || entry.validity_type != data.ValidityType
+    || entry.validity_type != data.ValidityType as i32
   {
     Err(report!(InvalidIpnsV2SignatureData))
   } else {
@@ -184,7 +184,7 @@ struct SignatureV2Data {
   Value: Vec<u8>,
   #[serde(with = "serde_bytes")]
   Validity: Vec<u8>,
-  ValidityType: i32,
+  ValidityType: u64,
   Sequence: u64,
   TTL: u64,
 }


### PR DESCRIPTION
Fixes #35

## Summary
This PR provides a complete fix for IPNS V2 record compatibility, handling both server-side validation requirements and backward compatibility with existing records.

## The Problem Evolution

1. **Original Issue**: w3name service rejected records with "Field validityType did not match between protobuf and CBOR"
2. **Initial Misdiagnosis**: Thought server required V2-only format (empty V1 fields)
3. **Actual Root Cause**: ValidityType data type mismatch (`i32` vs `u64`)
4. **Side Effect**: Created V2-only records that couldn't be resolved by clients

## The Complete Solution (4 commits)

### 1. `542a8bc`: V2-only format attempt
- Removed V1 fields thinking server required pure V2
- Fixed server validation but broke client resolution
- Created "orphaned" records

### 2. `23829af`: Restore V1 fields  
- Populated V1 fields to match V2 CBOR data
- Fixed new records but broke backward compatibility

### 3. `76b481a`: Fix ValidityType data type
- Changed CBOR ValidityType from `i32` to `u64` per IPNS spec
- Fixed the actual root cause

### 4. `644d85d`: Add backward compatibility
- Detect and handle V2-only records from commit #1
- Skip V1/V2 validation for old format
- Extract data from CBOR for old records

## Final Result

✅ **New records**: Full V1+V2 format with correct data types
✅ **Old records**: V2-only format handled transparently  
✅ **Server validation**: Passes with correct ValidityType
✅ **Client validation**: Works for both old and new formats
✅ **IPNS spec compliance**: Follows V1/V2 coexistence rules

## Testing
```bash
# Old V2-only records now work
./target/debug/w3name resolve k51qzi5uqu5dky230mjfhb0861a1mmo4m5f0sdka6nqth5qynloat2jm5glvqt
# ✅ Returns: /ipfs/baguqeerapofwes4jwsph7zbfj6jykewg33jvcitomsitqcxazylquewtzghq

# New records work with full validation
./target/debug/w3name create --output test.key
./target/debug/w3name publish --key test.key --value "/ipfs/test1"
./target/debug/w3name publish --key test.key --value "/ipfs/test2"  # Update works
```

## Impact
- No breaking changes for users
- Existing records continue to work
- New records are fully spec-compliant
- Complete backward and forward compatibility